### PR TITLE
Update 3DS.md

### DIFF
--- a/Nintendo/3DS.md
+++ b/Nintendo/3DS.md
@@ -8,7 +8,6 @@ Android:
 - [Mandarine3DS](https://github.com/mandarine3ds/mandarine/releases)
 
 iOS:
-- [RetroArch](https://apps.apple.com/ca/app/retroarch/id6499539433)
 - [Folium](https://apps.apple.com/ca/app/folium/id6498623389) (Paid)
 
 Windows/MacOS/Linux:


### PR DESCRIPTION
Removed RetroArch from the iOS section since it doesn’t support 3ds games on iOS